### PR TITLE
Do not allow validation step update; handle creation in pre_Add event

### DIFF
--- a/phpunit/functional/ValidationStepTest.php
+++ b/phpunit/functional/ValidationStepTest.php
@@ -273,27 +273,6 @@ class ValidationStepTest extends \DbTestCase
             $this->assertFalse($itil_validationstep->getFromDB($itil_validationstep_id), 'The ITIL validation step should not in database');
         }
     }
-    public function testItilValidationStepIsRemovedWhenValidationIsUpdated(): void
-    {
-        $this->login();
-        foreach ([\Ticket::class, \Change::class] as $itil_class) {
-            // arrange - create a validation (+ an itils_validationstep)
-            $vs = $this->createValidationStep(100);
-            [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::ACCEPTED], itil_classname: $itil_class);
-            $itil_validationstep_id = $itil_validationstep->getID();
-
-            $validation = $itil::getValidationClassInstance();
-            $validation_exists = $validation->getFromDBByCrit([$itil::getForeignKeyField() => $itil->getID(), 'itils_validationsteps_id' => $itil_validationstep_id]);
-            assert($validation_exists);
-
-            // act - update the validation to use another validation step
-            $new_vs = $this->createValidationStep(100);
-            $this->updateItem($validation::class, $validation->getID(), ['_validationsteps_id' => $new_vs->getID()]);
-
-            // assert - the itils_validationstep is deleted
-            $this->assertFalse($itil_validationstep->getFromDB($itil_validationstep_id), 'The ITIL validation step should not be in database');
-        }
-    }
 
     public function testGetValidationStepClassName(): void
     {

--- a/phpunit/src/CommonITILValidationTest.php
+++ b/phpunit/src/CommonITILValidationTest.php
@@ -1273,24 +1273,17 @@ abstract class CommonITILValidationTest extends DbTestCase
         $this->assertEquals($validationstep->getID(), $itil_validationstep->fields['validationsteps_id'], 'Validationstep not correctly set using _validationsteps_id');
         $this->assertEquals($validationstep->fields['minimal_required_validation_percent'], $itil_validationstep->fields['minimal_required_validation_percent']);
 
-        // act 2 : update validation step & threshold
-        $new_validationstep = $this->createValidationStep(100);
-        assert($new_validationstep->fields['minimal_required_validation_percent'] !== $threshold, 'can not test with the same threshold');
-
+        // act 2 : update validation threshold
         $validation = $this->updateItem(
             $validation::class,
             $validation->getID(),
             [
                 '_validationsteps_threshold' => $threshold,
-                '_validationsteps_id' => $new_validationstep->getID(),
-
             ]
         );
 
         // assert
         $itil_validationstep->getFromDB($validation->fields['itils_validationsteps_id']);
-
-        $this->assertEquals($new_validationstep->getID(), $itil_validationstep->fields['validationsteps_id'], 'Validationstep not correctly set using _validationsteps_id');
         $this->assertEquals($threshold, $itil_validationstep->fields['minimal_required_validation_percent']);
     }
 

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -178,34 +178,46 @@
             <input type="hidden" name="{{ item.getForeignKeyField() }}" value="{{ item.fields['id'] }}" />
 
             <div class="card-body">
-               {% if subitem.isNewItem() %}
-                  {# Validation template #}
-                  {{ fields.dropdownField(
-                     'ITILValidationTemplate',
-                     'itilvalidationtemplates_id',
-                     '',
-                     _n('Template', 'Templates', 1),
-                     {
-                        'full_width': true,
-                        'on_change': 'itilvalidationtemplate_update' ~ rand ~ '(this.value);',
-                        'entity': item.fields['entities_id'],
-                        'rand': rand,
-                     },
-                  ) }}
-               {% endif %}
+                {% if subitem.isNewItem() %}
+                    {# Validation template #}
+                    {{ fields.dropdownField(
+                        'ITILValidationTemplate',
+                        'itilvalidationtemplates_id',
+                        '',
+                        _n('Template', 'Templates', 1),
+                        {
+                            'full_width': true,
+                            'on_change': 'itilvalidationtemplate_update' ~ rand ~ '(this.value);',
+                            'entity': item.fields['entities_id'],
+                            'rand': rand,
+                        },
+                    ) }}
 
-               {# Validation step #}
-               {{ fields.dropdownField(
-                  'ValidationStep',
-                  '_validationsteps_id',
-                  _validationsteps_id,
-                  _n('Approval step', 'Approval step', 1),
-                  {
-                     'full_width': true,
-                     'rand': rand,
-                     'required': true,
-                  }
-               ) }}
+                    {# Validation step #}
+                    {{ fields.dropdownField(
+                        'ValidationStep',
+                        '_validationsteps_id',
+                        _validationsteps_id,
+                        _n('Approval step', 'Approval step', 1),
+                        {
+                            'full_width': true,
+                            'rand': rand,
+                            'required': true,
+                        }
+                    ) }}
+                {% else %}
+                    {{ fields.readOnlyField(
+                        '',
+                        get_item_name(
+                            'ValidationStep',
+                            get_item(item.getValidationStepClassName(), subitem.fields['itils_validationsteps_id']).fields['validationsteps_id']
+                        ),
+                        _n('Approval step', 'Approval step', 1),
+                        {
+                            'full_width': true,
+                        }
+                    ) }}
+                {% endif %}
 
                 {# Requester #}
                 {{ fields.readOnlyField(


### PR DESCRIPTION
1. Changer l'étape à laquelle est affectée une validation est trop dangereux fonctionnellement. Selon le cas d'usage, la réponse sera différente si l'étape est différente (par exemple on peut valider une demande liée à l'étape avant-vente mais la bloquer à l'épate vente).
Les changements proposés permettent de bloquer le changement d'étape de la même façon qu'est bloqué le changement de cible (`itemtype_target`/`items_id_target`).
Ce blocage a été validé avec François.

2. Déplacer la définition de la création de l'objet `ITIL_ValidationStep` de `post_addItem` à `pre_addInDB` permet d'éviter de devoir faire une mise à jour de la validation qui vient d'être crée.