### PR TITLE
Make some methods non static

### DIFF
--- a/phpunit/functional/ValidationStepTest.php
+++ b/phpunit/functional/ValidationStepTest.php
@@ -171,8 +171,8 @@ class ValidationStepTest extends \DbTestCase
         foreach ([\Ticket::class, \Change::class] as $itil_class) {
             $validation_step = $this->createValidationStep($mininal_required_validation_percent);
             // single itil_validation step with 100% required
-            [$itil, $itils_validationstep] = $this->createITILSValidationStepWithValidations($validation_step, $validation_states, itil_classname: $itil_class);
-            $result_status = $itil::getValidationStepClassName()::getITILValidationStepStatus($itils_validationstep->getID());
+            [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($validation_step, $validation_states, itil_classname: $itil_class);
+            $result_status = $itil_validationstep->getStatus();
 
             $this->assertValidationStatusEquals($expected_status, $result_status);
         }
@@ -185,17 +185,17 @@ class ValidationStepTest extends \DbTestCase
             $vs = $this->createValidationStep(100);
             // accepted
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::ACCEPTED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(100, $achievements[CommonITILValidation::ACCEPTED]);
 
             // refused
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::REFUSED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(100, $achievements[CommonITILValidation::REFUSED]);
 
             // waiting
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::WAITING], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(100, $achievements[CommonITILValidation::WAITING]);
         }
     }
@@ -207,46 +207,46 @@ class ValidationStepTest extends \DbTestCase
             $vs = $this->createValidationStep(100);
             // 2 validations with same status
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(100, $achievements[CommonITILValidation::ACCEPTED]);
             // test sum of % is 100
             $this->assertEquals(100, array_sum($achievements));
 
             // multiple validations with same status
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(100, $achievements[CommonITILValidation::WAITING]);
             $this->assertEquals(100, array_sum($achievements));
 
             // multiple validations with different status
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(50, $achievements[CommonITILValidation::WAITING]);
             $this->assertEquals(50, $achievements[CommonITILValidation::REFUSED]);
             $this->assertEquals(100, array_sum($achievements));
 
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(33, $achievements[CommonITILValidation::REFUSED]);
             $this->assertEquals(34, $achievements[CommonITILValidation::ACCEPTED]);
             $this->assertEquals(33, $achievements[CommonITILValidation::WAITING]);
 
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(67, $achievements[CommonITILValidation::REFUSED]);
             $this->assertEquals(33, $achievements[CommonITILValidation::ACCEPTED]);
             $this->assertEquals(0, $achievements[CommonITILValidation::WAITING]);
 
             // 4 validations with different status
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(50, $achievements[CommonITILValidation::WAITING]);
             $this->assertEquals(25, $achievements[CommonITILValidation::REFUSED]);
             $this->assertEquals(25, $achievements[CommonITILValidation::ACCEPTED]);
 
             // 5 validations with different status
             [$itil, $itil_validationstep] = $this->createITILSValidationStepWithValidations($vs, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED], itil_classname: $itil_class);
-            $achievements = $itil::getValidationStepClassName()::getITILValidationStepAchievements($itil_validationstep->getID());
+            $achievements = $itil_validationstep->getAchievements();
             $this->assertEquals(60, $achievements[CommonITILValidation::REFUSED]);
             $this->assertEquals(40, $achievements[CommonITILValidation::ACCEPTED]);
             $this->assertEquals(100, array_sum($achievements));

--- a/phpunit/src/Glpi/ValidationStepTrait.php
+++ b/phpunit/src/Glpi/ValidationStepTrait.php
@@ -104,11 +104,11 @@ trait ValidationStepTrait
         // check created itil validation step has the exepected status
         // expected status is explicitely given in argument
         if (!is_null($expected_status)) {
-            $checked_status = $ivs::getITILValidationStepStatus($ivs->getID());
+            $checked_status = $ivs->getStatus();
             assert($expected_status === $checked_status, 'failed to create itil_validation step with status ' . $this->statusToLabel($expected_status) . ' it has status ' . $this->statusToLabel($checked_status));
         } elseif (count($validations_statuses) === 1 && $validations_statuses[0] !== CommonITILValidation::NONE) {
             // expected status is implicitely the only status given in argument (except NONE)
-            $checked_status = $ivs::getITILValidationStepStatus($ivs->getID());
+            $checked_status = $ivs->getStatus();
             assert($validations_statuses[0] === $checked_status, 'failed to create itil_validation step with status ' . $this->statusToLabel($validations_statuses[0]) . ' it has status ' . $this->statusToLabel($checked_status));
         }
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1108,8 +1108,8 @@ abstract class CommonITILValidation extends CommonDBChild
                 $edit_button = $this->getModalFormHtmlElements('editapproval_modal', __('Edit Approval'), $itil->getID(), $validation["id"]) + ['anchor_title' => __('Edit') ];
             }
 
-            $itils_validationsteps_id = $validation['itils_validationsteps_id'];
-            $validations[$itils_validationsteps_id]['entries'][] = [
+            $itil_validationstep_id = $validation['itils_validationsteps_id'];
+            $validations[$itil_validationstep_id]['entries'][] = [
                 'edit'                  => $edit_button,
                 'status'                => $status,
                 'type_name'             => $type_name,
@@ -1123,9 +1123,9 @@ abstract class CommonITILValidation extends CommonDBChild
                 'user'                  => getUserName($validation["users_id"]),
             ];
 
-            $itil_edit_js_identifier = 'itilvalidation_edit_' . $itils_validationsteps_id;
-            $url = $itil::getValidationStepClassName()::getFormURLWithId($itils_validationsteps_id);
-            $validations[$itils_validationsteps_id]['edit_link_js']['js'] = Ajax::createIframeModalWindow(
+            $itil_edit_js_identifier = 'itilvalidation_edit_' . $itil_validationstep_id;
+            $url = $itil::getValidationStepClassName()::getFormURLWithId($itil_validationstep_id);
+            $validations[$itil_validationstep_id]['edit_link_js']['js'] = Ajax::createIframeModalWindow(
                 $itil_edit_js_identifier,
                 $url,
                 [
@@ -1135,23 +1135,22 @@ abstract class CommonITILValidation extends CommonDBChild
                     'height'          => 120,
                 ]
             );
-            $validations[$itils_validationsteps_id]['edit_link_js']['target'] = "$itil_edit_js_identifier";
+            $validations[$itil_validationstep_id]['edit_link_js']['target'] = "$itil_edit_js_identifier";
 
-            if ($itils_validationsteps_id !== $validationstep_id_inloop) {
-                $itils_validationsteps = $itil::getValidationStepInstance();
-                $itils_validationsteps->getFromDB($itils_validationsteps_id);
-                if (!$itils_validationsteps->getFromDB($itils_validationsteps_id)) {
-                    throw new Exception("itil Approval step not found " . $itils_validationsteps_id);
+            if ($itil_validationstep_id !== $validationstep_id_inloop) {
+                $itil_validationstep = $itil::getValidationStepInstance();
+                if (!$itil_validationstep->getFromDB($itil_validationstep_id)) {
+                    throw new Exception("itil Approval step not found " . $itil_validationstep_id);
                 }
 
-                $validation_step_status = $itils_validationsteps::getITILValidationStepStatus($itils_validationsteps_id);
-                $validation_step_achievements = $itils_validationsteps::getITILValidationStepAchievements($itils_validationsteps_id);
+                $validation_step_status = $itil_validationstep->getStatus();
+                $validation_step_achievements = $itil_validationstep->getAchievements();
 
-                $vs = $itils_validationsteps;
+                $vs = $itil_validationstep;
                 $vs->getFromDB($validation['itils_validationsteps_id']);
                 $validationsteps_id = $vs->fields['validationsteps_id'];
 
-                $validations[$itils_validationsteps_id]['validationstep'] = [
+                $validations[$itil_validationstep_id]['validationstep'] = [
                     'id' => $validation['itils_validationsteps_id'],
                     'name' => Dropdown::getDropdownName(ValidationStep::getTable(), $validationsteps_id),
                     // structured to be later replaced by a DTO with Status::isAccepted()|isRefused()|isWaiting() & getStatus()
@@ -1166,10 +1165,10 @@ abstract class CommonITILValidation extends CommonDBChild
                         'refused' => $validation_step_achievements[self::REFUSED],
                         'accepted' => $validation_step_achievements[self::ACCEPTED],
                     ],
-                    'minimal_required_validation_percent' => $itils_validationsteps->fields['minimal_required_validation_percent'],
+                    'minimal_required_validation_percent' => $itil_validationstep->fields['minimal_required_validation_percent'],
                 ];
 
-                $validationstep_id_inloop = $itils_validationsteps_id;
+                $validationstep_id_inloop = $itil_validationstep_id;
             }
         }
 


### PR DESCRIPTION
La méthode était utilisée dans des cas où l'objet est déjà chargé. Utiliser l'instance de l'objet plutôt que de devoir le recharger dans une méthode statique va réduire légèrement le nombre de requêtes.

Aussi, il est préférable d'éviter autant que possible les méthodes statiques, c'est souvent plus compliqué à gérer dans les tests car ça favorise le chaînage des méthodes statiques qui empêchent l'utilisation de mocks. 