### PR TITLE
Revue des migrations

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/validationsteps.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/validationsteps.php
@@ -32,6 +32,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\DBAL\QuerySubQuery;
+
 /**
  * @var \DBmysql $DB
  * @var \Migration $migration
@@ -40,23 +42,14 @@
 $validation_tables = ['glpi_ticketvalidations', 'glpi_changevalidations'];
 $itil_tables = ['glpi_tickets', 'glpi_changes'];
 
-if (is_validationstep_migration_done($itil_tables, $DB, $migration)) {
-    $migration->log('ValidationSteps migration already done', true);
-
-    return;
-}
-
-$migration->log('Preparing ValidationSteps migration', false);
-
 // new object : ValidationStep
-create_validation_steps_table($migration);
+create_validation_steps_table($migration, $DB);
 insert_validation_steps_defaults($migration, $DB);
 
 // new object : ITIL_ValidationStep - Association between Validations and ValidationSteps + minimal_required_validation_percent
 create_itils_validationsteps_table($migration, $DB);
 add_validation_steps_in_validations_tables($migration, $validation_tables);
-$migration->executeMigration();
-add_itils_validationstep_to_existings_itils($migration, $validation_tables);
+add_itils_validationstep_to_existings_itils($migration, $DB, $validation_tables);
 
 // templates
 add_approval_status_to_ticket_templates($migration);
@@ -66,17 +59,19 @@ remove_validation_percent_on_itils($migration, $itil_tables);
 
 migrate_validation_rules($DB, $migration);
 
-$migration->executeMigration();
-$migration->log('ValidationSteps migration done', false);
-
 return;
-function create_validation_steps_table(Migration $migration): void
+
+function create_validation_steps_table(Migration $migration, DBmysql $DB): void
 {
+    if ($DB->tableExists('glpi_validationsteps')) {
+        return;
+    }
+
     $charset = DBConnection::getDefaultCharset();
     $collation = DBConnection::getDefaultCollation();
     $pk_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-    $query = "CREATE TABLE IF NOT EXISTS `glpi_validationsteps` (
+    $DB->doQuery("CREATE TABLE IF NOT EXISTS `glpi_validationsteps` (
         `id`                                  int {$pk_sign}     NOT NULL AUTO_INCREMENT,
         `name`                                varchar(255)       DEFAULT NULL,
         `minimal_required_validation_percent` tinyint unsigned   NOT NULL DEFAULT '100',
@@ -84,72 +79,53 @@ function create_validation_steps_table(Migration $migration): void
         `date_mod`                            timestamp          NULL DEFAULT NULL,
         `date_creation`                       timestamp          NULL DEFAULT NULL,
         `comment`                             text,
-        PRIMARY KEY (`id`)
-    ) ENGINE=InnoDB DEFAULT CHARSET=$charset COLLATE=$collation ROW_FORMAT=DYNAMIC;";
-
-    $migration->addPreQuery($query);
-    // $migration needs to be executed before adding keys
-    // because addKey() checks if key exists, so the table must exists
-    $migration->executeMigration();
-
-    $migration->addKey('glpi_validationsteps', 'name');
-    $migration->addKey('glpi_validationsteps', 'date_mod');
-    $migration->addKey('glpi_validationsteps', 'date_creation');
+        PRIMARY KEY (`id`),
+        KEY `name` (`name`),
+        KEY `date_mod` (`date_mod`),
+        KEY `date_creation` (`date_creation`)
+    ) ENGINE=InnoDB DEFAULT CHARSET={$charset} COLLATE={$collation} ROW_FORMAT=DYNAMIC;");
 }
 
-function insert_validation_steps_defaults(Migration $migration, \DBmysql $DB): void
+function insert_validation_steps_defaults(Migration $migration, DBmysql $DB): void
 {
-    if (!$DB->tableExists('glpi_validationsteps')) {
-        $message = 'ValidationSteps table does not exist, skipping defaults insertion';
-        $migration->log($message, true);
-        throw new \LogicException($message);
+    if (countElementsInTable('glpi_validationsteps') > 0) {
+        return;
     }
 
-    $table_empty = (new DbUtils())->countElementsInTable('glpi_validationsteps') === 0;
-    if (!$table_empty) {
-        $message = 'ValidationSteps table already filled, skipping defaults insertion';
-        $migration->log($message, true);
-        throw new \LogicException($message);
-    }
-
-    $default = [
-        'id' => 1,
-        'name' => _n('Approval', 'Approvals', 1),
-        'minimal_required_validation_percent' => 100,
-        'is_default' => 1,
-        'date_creation' => date('Y-m-d H:i:s'),
-        'date_mod' => date('Y-m-d H:i:s'),
-        'comment' => '',
-    ];
-    $migration->addPostQuery(
-        $DB->buildInsert('glpi_validationsteps', $default)
+    $migration->insertInTable(
+        'glpi_validationsteps',
+        [
+            'id' => 1,
+            'name' => _n('Approval', 'Approvals', 1),
+            'minimal_required_validation_percent' => 100,
+            'is_default' => 1,
+            'date_creation' => date('Y-m-d H:i:s'),
+            'date_mod' => date('Y-m-d H:i:s'),
+            'comment' => '',
+        ]
     );
 }
 
-function create_itils_validationsteps_table(Migration $migration, \DBmysql $DB): void
+function create_itils_validationsteps_table(Migration $migration, DBmysql $DB): void
 {
+    if ($DB->tableExists('glpi_itils_validationsteps')) {
+        return;
+    }
+
     $charset = DBConnection::getDefaultCharset();
     $collation = DBConnection::getDefaultCollation();
     $pk_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-    if (!$DB->tableExists('glpi_itils_validationsteps')) {
-        $query = "CREATE TABLE `glpi_itils_validationsteps` (
-            `id`                                    int {$pk_sign}        NOT NULL AUTO_INCREMENT,
-            `minimal_required_validation_percent`   tinyint unsigned      NOT NULL,
-            `validationsteps_id`                    int {$pk_sign}        NOT NULL DEFAULT '0',
-            `itemtype`                              varchar(255)          NOT NULL,
-            `items_id`                              int {$pk_sign}        NOT NULL DEFAULT '0',
-            PRIMARY KEY (`id`),
-            UNIQUE KEY `unicity` (`itemtype`,`items_id`,`validationsteps_id`),
-            KEY `validationsteps_id` (`validationsteps_id`)
-        ) ENGINE=InnoDB DEFAULT CHARSET=$charset COLLATE=$collation ROW_FORMAT=DYNAMIC;";
-
-        $migration->addPreQuery($query);
-    } else {
-        $migration->addField('glpi_itils_validationsteps', 'itemtype', 'varchar(255) NOT NULL');
-        $migration->addField('glpi_itils_validationsteps', 'items_id', 'fkey');
-        $migration->addKey('glpi_itils_validationsteps', ['itemtype', 'items_id', 'validationsteps_id'], 'unicity');
-    }
+    $DB->doQuery("CREATE TABLE `glpi_itils_validationsteps` (
+        `id`                                    int {$pk_sign}        NOT NULL AUTO_INCREMENT,
+        `minimal_required_validation_percent`   tinyint unsigned      NOT NULL,
+        `validationsteps_id`                    int {$pk_sign}        NOT NULL DEFAULT '0',
+        `itemtype`                              varchar(255)          NOT NULL,
+        `items_id`                              int {$pk_sign}        NOT NULL DEFAULT '0',
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `unicity` (`itemtype`,`items_id`,`validationsteps_id`),
+        KEY `validationsteps_id` (`validationsteps_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=$charset COLLATE=$collation ROW_FORMAT=DYNAMIC;");
 }
 
 
@@ -165,8 +141,6 @@ function add_validation_steps_in_validations_tables(Migration $migration, array 
             $itils_validationsteps_foreign_key,
             'fkey',
             [
-                'value' => '0',
-                'null' => false,
                 'after' => 'id',
             ]
         );
@@ -205,8 +179,6 @@ function add_validation_steps_in_itilvalidationtemplates(Migration $migration): 
         $validationsteps_foreign_key,
         'fkey',
         [
-            'value' => '0',
-            'null' => false,
             'after' => 'is_recursive',
         ]
     );
@@ -218,43 +190,67 @@ function add_validation_steps_in_itilvalidationtemplates(Migration $migration): 
  *
  * Create an ITIL_ValidationStep for each validation (but only one per itil)
  */
-function add_itils_validationstep_to_existings_itils(Migration $migration, array $validation_tables): void
+function add_itils_validationstep_to_existings_itils(Migration $migration, DBmysql $DB, array $validation_tables): void
 {
     foreach ($validation_tables as $validation_table) {
-        /** @var class-string<\CommonITILValidation> $validation_classname */
-        $validation_classname = match ($validation_table) {
-            'glpi_ticketvalidations' => \TicketValidation::class,
-            'glpi_changevalidations' => \ChangeValidation::class,
+        $itil_class = match ($validation_table) {
+            'glpi_ticketvalidations' => 'Ticket',
+            'glpi_changevalidations' => 'Change',
             default => throw new \RuntimeException('Unexpected validation table: ' . $validation_table),
         };
-
-        $itil_class = $validation_classname::getItilObjectItemType();
+        $itil_table = match ($itil_class) {
+            'Ticket' => 'glpi_tickets',
+            'Change' => 'glpi_changes',
+        };
         $itil_fk = match ($itil_class) {
             'Ticket' => 'tickets_id',
             'Change' => 'changes_id',
-            default => throw new \RuntimeException('Unexpected itil class: ' . $itil_class),
         };
 
-        $default_validation_step = ValidationStep::getDefault(); // previous sql needs to be processed before
-        $validations = getAllDataFromTable($validation_table, ['GROUPBY' => $itil_fk]); // TicketValidation or ChangeValidation data
-        foreach ($validations as $validation) {
-            // get current required percent on itil
-            $itil = new $itil_class();
-            $itil->getFromDB($validation[$itil_fk]);
-            $required_percent = $itil->fields['validation_percent'];
+        if (!$DB->fieldExists($itil_table, 'validation_percent')) {
+            // The migration has already been done.
+            continue;
+        }
 
+        $default_validation_step_id = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => 'glpi_validationsteps',
+            'WHERE'  => ['is_default' => 1],
+        ])->current()['id'];
+
+        // Get itil objects having at least one validation
+        $itils_iterator = $DB->request([
+            'SELECT' => ['id', 'validation_percent'],
+            'FROM'   => $itil_table,
+            'WHERE'  => [
+                'id' => new QuerySubQuery([
+                    'SELECT' => $itil_fk,
+                    'FROM'   => $validation_table,
+                ]),
+            ],
+        ]);
+        foreach ($itils_iterator as $itil) {
             // create itils_validationsteps
             $itils_validationstep_id = $migration->insertInTable(
                 'glpi_itils_validationsteps',
                 [
                     'itemtype' => $itil_class,
-                    'items_id' => $validation[$itil_fk],
-                    'validationsteps_id' => $default_validation_step->getID(),
-                    'minimal_required_validation_percent' => $required_percent,
+                    'items_id' => $itil['id'],
+                    'validationsteps_id' => $default_validation_step_id,
+                    'minimal_required_validation_percent' => $itil['validation_percent'],
                 ]
             );
+
             // update itils validations (ticket, change) with the created itils_validationsteps
-            $update_validation_query = 'UPDATE ' . $validation_table . ' SET ' . 'itils_validationsteps_id' . ' = ' . $itils_validationstep_id . ' WHERE ' . $itil_fk . ' = ' . $validation[$itil_fk];
+            $update_validation_query = $DB->buildUpdate(
+                $validation_table,
+                [
+                    'itils_validationsteps_id' => $itils_validationstep_id,
+                ],
+                [
+                    $itil_fk => $itil['id'],
+                ]
+            );
             $migration->addPostQuery($update_validation_query);
         }
     }
@@ -265,14 +261,6 @@ function remove_validation_percent_on_itils(Migration $migration, array $itil_ta
     foreach ($itil_tables as $table) {
         $migration->dropField($table, 'validation_percent');
     }
-}
-
-/**
- * Check if the migration is already done by checking if validation_percent field is removed on first itil table
- */
-function is_validationstep_migration_done($itil_tables, \DBmysql $DB, Migration $migration): bool
-{
-    return !$DB->fieldExists($itil_tables[0], 'validation_percent', false);
 }
 
 /**

--- a/install/migrations/update_10.0.x_to_11.0.0/validationsteps.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/validationsteps.php
@@ -260,6 +260,13 @@ function remove_validation_percent_on_itils(Migration $migration, array $itil_ta
 {
     foreach ($itil_tables as $table) {
         $migration->dropField($table, 'validation_percent');
+
+        $itil_class = match ($table) {
+            'glpi_tickets' => 'Ticket',
+            'glpi_changes' => 'Change',
+            default => throw new \RuntimeException('Unexpected ITIL table: ' . $table),
+        };
+        $migration->removeSearchOption($itil_class, 51); // 51 = validation_percent
     }
 }
 


### PR DESCRIPTION
1. Supprime l'usage de `executeMigration` et fait en sorte de pouvoir rejouer toutes les fonctions de la mirgation.
2. Suppression des données liés à la search option 51 qui a été supprimée.